### PR TITLE
Add ESP32-C3 LoRa↔MQTT gateway skeleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,98 @@
-# esp32-c3-lora-mqtt-gateway
+# ESP32-C3 LoRa ⇄ MQTT Gateway
+
+This project implements a simple LoRa to MQTT gateway for an ESP32-C3 board
+paired with an **SX1262** LoRa transceiver.  The gateway listens for LoRa
+packets from remote devices, forwards their data to MQTT topics and relays
+commands from MQTT back to the devices.  It also publishes basic diagnostic
+information suitable for Home Assistant.
+
+## Hardware wiring
+
+RadioLib style wiring is used.  Connect the SX1262 module to the ESP32‑C3 as
+shown below:
+
+| SX1262 Pin | ESP32‑C3 GPIO |
+|------------|---------------|
+| NSS        | 7             |
+| SCK        | 4             |
+| MISO       | 5             |
+| MOSI       | 6             |
+| DIO1       | 9             |
+| BUSY       | 3             |
+| RST        | 8             |
+| VCC        | 3V3           |
+| GND        | GND           |
+
+## Packet format
+
+LoRa packets use a very small, colon separated layout:
+
+```
+DEVICE_ID:MSG_TYPE:PAYLOAD
+```
+
+Example registration packet from a temperature sensor:
+
+```
+temp1:register:temperature
+```
+
+Data packet from the same sensor:
+
+```
+temp1:data:23.5
+```
+
+## MQTT topics
+
+For each registered device the gateway exposes two MQTT topics:
+
+```
+lora/<device_id>/state   – published telemetry from the device
+lora/<device_id>/cmd     – subscribed commands sent to the device
+```
+
+Gateway diagnostics are published to:
+
+```
+lora/gateway/state
+lora/gateway/stats
+```
+
+The `stats` topic publishes a JSON document containing WiFi RSSI, last LoRa
+RSSI/SNR, uptime and number of registered devices.  Topics are retained so
+Home Assistant can easily discover them.
+
+## Building
+
+1. Install [PlatformIO](https://platformio.org/install).
+2. Rename `include/config.h` values with your WiFi and MQTT credentials if
+   necessary.
+3. Build the project:
+
+   ```bash
+   pio run
+   ```
+
+4. Upload to the board:
+
+   ```bash
+   pio run --target upload
+   ```
+
+Example sketches are provided in the `examples/` directory showing how a
+remote temperature sensor registers itself and how a relay device listens for
+commands over LoRa.
+
+## Home Assistant integration
+
+Use MQTT discovery or manually configure sensors and switches using the topics
+above.  Gateway statistics are provided in JSON making it easy to track WiFi
+signal strength, last packet RSSI/SNR, uptime and the number of registered
+LoRa devices.
+
+## License
+
+This project is released under the MIT license.  See [LICENSE](LICENSE) for
+more information.
+

--- a/examples/Relay/Relay.ino
+++ b/examples/Relay/Relay.ino
@@ -1,0 +1,29 @@
+#include <Arduino.h>
+#include "LoRaHandler.h"
+#include "DeviceTypes/RelayDevice.h"
+#include "config.h"
+
+LoRaHandler lora;
+bool relayState = false;
+
+void setup() {
+  Serial.begin(115200);
+  lora.begin();
+  lora.sendPacket("relay1:register:relay");
+}
+
+void loop() {
+  int rssi; float snr;
+  if (lora.available()) {
+    String pkt = lora.receivePacket(rssi, snr);
+    int first = pkt.indexOf(':');
+    int second = pkt.indexOf(':', first + 1);
+    String msgType = pkt.substring(first + 1, second);
+    String payload = pkt.substring(second + 1);
+    if (msgType == "cmd") {
+      relayState = RelayDevice::decode(payload);
+      Serial.println(String("Relay state: ") + (relayState ? "ON" : "OFF"));
+    }
+  }
+}
+

--- a/examples/TemperatureSensor/TemperatureSensor.ino
+++ b/examples/TemperatureSensor/TemperatureSensor.ino
@@ -1,0 +1,21 @@
+#include <Arduino.h>
+#include "LoRaHandler.h"
+#include "DeviceTypes/TemperatureSensorDevice.h"
+#include "config.h"
+
+LoRaHandler lora;
+
+void setup() {
+  Serial.begin(115200);
+  lora.begin();
+  // send registration packet: DEVICE_ID:MSG_TYPE:PAYLOAD
+  lora.sendPacket("temp1:register:temperature");
+}
+
+void loop() {
+  float temperatureC = 24.3;
+  String payload = TemperatureSensorDevice::encode(temperatureC);
+  lora.sendPacket(String("temp1:data:") + payload);
+  delay(10000);
+}
+

--- a/include/config.h
+++ b/include/config.h
@@ -1,0 +1,32 @@
+#pragma once
+
+#include <Arduino.h>
+
+// WiFi credentials
+extern const char *WIFI_SSID;
+extern const char *WIFI_PASSWORD;
+
+// MQTT settings
+extern const char *MQTT_HOST;
+extern const uint16_t MQTT_PORT;
+extern const char *MQTT_USER;
+extern const char *MQTT_PASSWORD;
+
+// LoRa radio pins (SX1262)
+#define LORA_MOSI 6
+#define LORA_MISO 5
+#define LORA_SCK 4
+#define LORA_CS 7
+#define LORA_RST 8
+#define LORA_BUSY 3
+#define LORA_DIO1 9
+
+// LoRa radio parameters
+extern const float LORA_FREQ;
+extern const float LORA_BW;
+extern const uint8_t LORA_SF;
+extern const uint8_t LORA_CR;
+
+// Gateway stats publish interval (ms)
+extern const uint32_t GATEWAY_STATS_INTERVAL;
+

--- a/platformio.ini
+++ b/platformio.ini
@@ -1,0 +1,15 @@
+[platformio]
+default_envs = esp32c3
+[env:esp32c3]
+platform = espressif32
+board = esp32-c3-devkitm-1
+framework = arduino
+monitor_speed = 115200
+lib_deps =
+    jgromes/RadioLib@^6.0.0
+    knolleary/PubSubClient@^2.8
+
+[env:native]
+platform = native
+lib_deps =
+    knolleary/PubSubClient@^2.8

--- a/src/DeviceRegistry.cpp
+++ b/src/DeviceRegistry.cpp
@@ -1,0 +1,18 @@
+#include "DeviceRegistry.h"
+
+void DeviceRegistry::registerDevice(const String &id, const String &type) {
+  devices[id] = {id, type};
+}
+
+bool DeviceRegistry::isRegistered(const String &id) const {
+  return devices.find(id) != devices.end();
+}
+
+String DeviceRegistry::getType(const String &id) const {
+  auto it = devices.find(id);
+  if (it != devices.end()) {
+    return it->second.type;
+  }
+  return String();
+}
+

--- a/src/DeviceRegistry.h
+++ b/src/DeviceRegistry.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include <Arduino.h>
+#include <map>
+
+struct RegisteredDevice {
+  String id;
+  String type;
+};
+
+class DeviceRegistry {
+ public:
+  void registerDevice(const String &id, const String &type);
+  bool isRegistered(const String &id) const;
+  String getType(const String &id) const;
+  size_t count() const { return devices.size(); }
+
+ private:
+  std::map<String, RegisteredDevice> devices;
+};
+

--- a/src/DeviceTypes/MoistureSensorDevice.h
+++ b/src/DeviceTypes/MoistureSensorDevice.h
@@ -1,0 +1,9 @@
+#pragma once
+#include <Arduino.h>
+
+class MoistureSensorDevice {
+ public:
+  static String encode(int percent) { return String(percent); }
+  static int decode(const String &payload) { return payload.toInt(); }
+};
+

--- a/src/DeviceTypes/RelayDevice.h
+++ b/src/DeviceTypes/RelayDevice.h
@@ -1,0 +1,9 @@
+#pragma once
+#include <Arduino.h>
+
+class RelayDevice {
+ public:
+  static String encode(bool on) { return on ? "ON" : "OFF"; }
+  static bool decode(const String &payload) { return payload == "ON"; }
+};
+

--- a/src/DeviceTypes/TemperatureSensorDevice.h
+++ b/src/DeviceTypes/TemperatureSensorDevice.h
@@ -1,0 +1,9 @@
+#pragma once
+#include <Arduino.h>
+
+class TemperatureSensorDevice {
+ public:
+  static String encode(float celsius) { return String(celsius, 2); }
+  static float decode(const String &payload) { return payload.toFloat(); }
+};
+

--- a/src/LoRaHandler.cpp
+++ b/src/LoRaHandler.cpp
@@ -1,0 +1,37 @@
+#include "LoRaHandler.h"
+#include "config.h"
+
+LoRaHandler::LoRaHandler()
+    : module(new Module(LORA_CS, LORA_DIO1, LORA_RST, LORA_BUSY)),
+      radio(module) {}
+
+int LoRaHandler::begin() {
+  SPI.begin(LORA_SCK, LORA_MISO, LORA_MOSI, LORA_CS);
+  int state = radio.begin(LORA_FREQ, LORA_BW, LORA_SF, LORA_CR);
+  if (state == RADIOLIB_ERR_NONE) {
+    radio.setDio1Action(nullptr);
+  }
+  return state;
+}
+
+bool LoRaHandler::sendPacket(const String &packet) {
+  String mutablePacket = packet;
+  int state = radio.transmit(mutablePacket);
+  return state == RADIOLIB_ERR_NONE;
+}
+
+bool LoRaHandler::available() {
+  if (radio.getPacketLength() > 0) {
+    return true;
+  }
+  return false;
+}
+
+String LoRaHandler::receivePacket(int &rssi, float &snr) {
+  String str;
+  radio.receive(str);
+  rssi = radio.getRSSI();
+  snr = radio.getSNR();
+  return str;
+}
+

--- a/src/LoRaHandler.h
+++ b/src/LoRaHandler.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include <RadioLib.h>
+#include <Arduino.h>
+
+class LoRaHandler {
+ public:
+  LoRaHandler();
+  int begin();
+  bool sendPacket(const String &packet);
+  bool available();
+  String receivePacket(int &rssi, float &snr);
+
+ private:
+  Module* module;
+  SX1262 radio;
+};
+

--- a/src/MqttHandler.cpp
+++ b/src/MqttHandler.cpp
@@ -1,0 +1,84 @@
+#include "MqttHandler.h"
+#include "config.h"
+
+MqttHandler *MqttHandler::instance = nullptr;
+
+MqttHandler::MqttHandler(DeviceRegistry &registry, LoRaHandler &lora)
+    : registry(registry), lora(lora), client(wifiClient), lastStats(0) {
+  instance = this;
+}
+
+void MqttHandler::begin() {
+  connectWifi();
+  client.setServer(MQTT_HOST, MQTT_PORT);
+  client.setCallback(MqttHandler::onMessage);
+  connectMqtt();
+}
+
+void MqttHandler::connectWifi() {
+  WiFi.mode(WIFI_STA);
+  WiFi.begin(WIFI_SSID, WIFI_PASSWORD);
+  while (WiFi.status() != WL_CONNECTED) {
+    delay(500);
+  }
+}
+
+void MqttHandler::connectMqtt() {
+  while (!client.connected()) {
+    if (client.connect("lora-gateway", MQTT_USER, MQTT_PASSWORD)) {
+      client.subscribe("lora/+/cmd");
+    } else {
+      delay(1000);
+    }
+  }
+}
+
+void MqttHandler::loop() {
+  if (WiFi.status() != WL_CONNECTED) {
+    connectWifi();
+  }
+  if (!client.connected()) {
+    connectMqtt();
+  }
+  client.loop();
+  unsigned long now = millis();
+  if (now - lastStats > GATEWAY_STATS_INTERVAL) {
+    publishGatewayStats(0, 0);
+    lastStats = now;
+  }
+}
+
+void MqttHandler::publishState(const String &topic, const String &payload) {
+  client.publish(topic.c_str(), payload.c_str(), true);
+}
+
+void MqttHandler::publishGatewayStats(int rssi, float snr) {
+  String payload = String("{") +
+                   "\"devices\":" + registry.count() +
+                   ",\"wifi_rssi\":" + WiFi.RSSI() +
+                   ",\"last_rssi\":" + rssi +
+                   ",\"last_snr\":" + snr +
+                   ",\"uptime\":" + (millis() / 1000) +
+                   "}";
+  client.publish("lora/gateway/stats", payload.c_str(), true);
+}
+
+void MqttHandler::onMessage(char *topic, byte *payload, unsigned int length) {
+  if (instance) {
+    instance->handleMessage(topic, payload, length);
+  }
+}
+
+void MqttHandler::handleMessage(char *topic, byte *payload, unsigned int length) {
+  String t = String(topic);
+  String data;
+  for (unsigned int i = 0; i < length; i++) {
+    data += (char)payload[i];
+  }
+  int first = t.indexOf('/');
+  int second = t.indexOf('/', first + 1);
+  String deviceId = t.substring(first + 1, second);
+  lora.sendPacket(deviceId + String(":cmd:") + data);
+  publishState(String("lora/") + deviceId + "/state", "cmd_sent");
+}
+

--- a/src/MqttHandler.h
+++ b/src/MqttHandler.h
@@ -1,0 +1,30 @@
+#pragma once
+
+#include <Arduino.h>
+#include <PubSubClient.h>
+#include <WiFi.h>
+#include "DeviceRegistry.h"
+#include "LoRaHandler.h"
+
+class MqttHandler {
+ public:
+  MqttHandler(DeviceRegistry &registry, LoRaHandler &lora);
+  void begin();
+  void loop();
+  void publishState(const String &topic, const String &payload);
+  void publishGatewayStats(int rssi, float snr);
+
+ private:
+  DeviceRegistry &registry;
+  LoRaHandler &lora;
+  WiFiClient wifiClient;
+  PubSubClient client;
+  unsigned long lastStats;
+
+  static MqttHandler *instance;
+  void connectWifi();
+  void connectMqtt();
+  static void onMessage(char *topic, byte *payload, unsigned int length);
+  void handleMessage(char *topic, byte *payload, unsigned int length);
+};
+

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -1,0 +1,18 @@
+#include "config.h"
+
+// Update these values for your network
+const char *WIFI_SSID = "YOUR_WIFI_SSID";
+const char *WIFI_PASSWORD = "YOUR_WIFI_PASSWORD";
+
+const char *MQTT_HOST = "mqtt.example.com";
+const uint16_t MQTT_PORT = 1883;
+const char *MQTT_USER = "mqtt_user";
+const char *MQTT_PASSWORD = "mqtt_pass";
+
+const float LORA_FREQ = 915.0;
+const float LORA_BW = 125.0;
+const uint8_t LORA_SF = 7;
+const uint8_t LORA_CR = 5;
+
+const uint32_t GATEWAY_STATS_INTERVAL = 60000; // 60s
+

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,0 +1,53 @@
+#include <Arduino.h>
+#include "config.h"
+#include "LoRaHandler.h"
+#include "MqttHandler.h"
+#include "DeviceRegistry.h"
+
+LoRaHandler lora;
+DeviceRegistry registry;
+MqttHandler mqtt(registry, lora);
+
+int lastRSSI = 0;
+float lastSNR = 0.0;
+
+void setup() {
+  Serial.begin(115200);
+  delay(1000);
+  Serial.println("LoRa MQTT Gateway starting");
+
+  if (lora.begin() != RADIOLIB_ERR_NONE) {
+    Serial.println("Failed to initialize LoRa radio");
+    while (true) {
+      delay(1000);
+    }
+  }
+
+  mqtt.begin();
+}
+
+void loop() {
+  mqtt.loop();
+
+  if (lora.available()) {
+    String packet = lora.receivePacket(lastRSSI, lastSNR);
+    int first = packet.indexOf(':');
+    int second = packet.indexOf(':', first + 1);
+    if (first > 0 && second > first) {
+      String deviceId = packet.substring(0, first);
+      String msgType = packet.substring(first + 1, second);
+      String payload = packet.substring(second + 1);
+
+      if (msgType == "register") {
+        registry.registerDevice(deviceId, payload); // payload contains device type
+        mqtt.publishState(String("lora/") + deviceId + "/state", "registered");
+      } else if (msgType == "data") {
+        if (registry.isRegistered(deviceId)) {
+          mqtt.publishState(String("lora/") + deviceId + "/state", payload);
+        }
+      }
+      mqtt.publishGatewayStats(lastRSSI, lastSNR);
+    }
+  }
+}
+

--- a/test/test_gateway.cpp
+++ b/test/test_gateway.cpp
@@ -1,0 +1,41 @@
+#include <Arduino.h>
+#include <unity.h>
+#include "DeviceRegistry.h"
+#include "DeviceTypes/TemperatureSensorDevice.h"
+#include "DeviceTypes/RelayDevice.h"
+
+void test_device_registration() {
+  DeviceRegistry reg;
+  String pkt = "temp1:register:temperature";
+  int first = pkt.indexOf(':');
+  int second = pkt.indexOf(':', first + 1);
+  String id = pkt.substring(0, first);
+  String type = pkt.substring(second + 1);
+  reg.registerDevice(id, type);
+  TEST_ASSERT_TRUE(reg.isRegistered("temp1"));
+  TEST_ASSERT_EQUAL_STRING("temperature", reg.getType("temp1").c_str());
+}
+
+void test_temperature_payload() {
+  float t = 23.5f;
+  String encoded = TemperatureSensorDevice::encode(t);
+  TEST_ASSERT_FLOAT_WITHIN(0.01f, t, TemperatureSensorDevice::decode(encoded));
+}
+
+void test_relay_payload() {
+  String encoded = RelayDevice::encode(true);
+  TEST_ASSERT_TRUE(RelayDevice::decode(encoded));
+  String packet = String("relay1:cmd:") + encoded;
+  TEST_ASSERT_EQUAL_STRING("relay1:cmd:ON", packet.c_str());
+}
+
+void setup() {
+  UNITY_BEGIN();
+  RUN_TEST(test_device_registration);
+  RUN_TEST(test_temperature_payload);
+  RUN_TEST(test_relay_payload);
+  UNITY_END();
+}
+
+void loop() {}
+


### PR DESCRIPTION
## Summary
- add PlatformIO project targeting ESP32-C3 and SX1262 radio
- implement LoRa handler, MQTT handler and device registry with example device types
- document packet format, wiring and MQTT topics; include example sketches and unit tests

## Testing
- `pio run`
- `pio test -e esp32c3 -f test_gateway --without-uploading` *(fails: undefined reference to DeviceRegistry::registerDevice)*

------
https://chatgpt.com/codex/tasks/task_e_68909f5b6670832ba96129d8dfa2908b