### PR TITLE
Add action acknowledgement with resend support

### DIFF
--- a/src/DeviceRegistry.cpp
+++ b/src/DeviceRegistry.cpp
@@ -1,7 +1,7 @@
 #include "DeviceRegistry.h"
 
-void DeviceRegistry::registerDevice(const String &id, const String &type) {
-  devices[id] = {id, type};
+void DeviceRegistry::registerDevice(const String &id, const String &type, bool requiresAck) {
+  devices[id] = {id, type, requiresAck};
 }
 
 bool DeviceRegistry::isRegistered(const String &id) const {
@@ -14,5 +14,13 @@ String DeviceRegistry::getType(const String &id) const {
     return it->second.type;
   }
   return String();
+}
+
+bool DeviceRegistry::requiresAck(const String &id) const {
+  auto it = devices.find(id);
+  if (it != devices.end()) {
+    return it->second.requiresAck;
+  }
+  return false;
 }
 

--- a/src/DeviceRegistry.h
+++ b/src/DeviceRegistry.h
@@ -6,13 +6,15 @@
 struct RegisteredDevice {
   String id;
   String type;
+  bool requiresAck;
 };
 
 class DeviceRegistry {
  public:
-  void registerDevice(const String &id, const String &type);
+  void registerDevice(const String &id, const String &type, bool requiresAck = false);
   bool isRegistered(const String &id) const;
   String getType(const String &id) const;
+  bool requiresAck(const String &id) const;
   size_t count() const { return devices.size(); }
 
  private:

--- a/src/MqttHandler.h
+++ b/src/MqttHandler.h
@@ -3,6 +3,7 @@
 #include <Arduino.h>
 #include <PubSubClient.h>
 #include <WiFi.h>
+#include <map>
 #include "DeviceRegistry.h"
 #include "LoRaHandler.h"
 
@@ -13,6 +14,7 @@ class MqttHandler {
   void loop();
   void publishState(const String &topic, const String &payload);
   void publishGatewayStats(int rssi, float snr);
+  void handleAck(const String &deviceId, const String &actionType);
 
  private:
   DeviceRegistry &registry;
@@ -21,10 +23,17 @@ class MqttHandler {
   PubSubClient client;
   unsigned long lastStats;
 
+  struct PendingAction {
+    String packet;
+    unsigned long lastSent;
+  };
+  std::map<String, std::map<String, PendingAction>> pending;
+
   static MqttHandler *instance;
   void connectWifi();
   void connectMqtt();
   static void onMessage(char *topic, byte *payload, unsigned int length);
   void handleMessage(char *topic, byte *payload, unsigned int length);
+  void checkPending();
 };
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -39,12 +39,22 @@ void loop() {
       String payload = packet.substring(second + 1);
 
       if (msgType == "register") {
-        registry.registerDevice(deviceId, payload); // payload contains device type
+        bool requireAck = false;
+        String type = payload;
+        int comma = payload.indexOf(',');
+        if (comma > 0) {
+          type = payload.substring(0, comma);
+          String flag = payload.substring(comma + 1);
+          requireAck = (flag == "ack");
+        }
+        registry.registerDevice(deviceId, type, requireAck);
         mqtt.publishState(String("lora/") + deviceId + "/state", "registered");
       } else if (msgType == "data") {
         if (registry.isRegistered(deviceId)) {
           mqtt.publishState(String("lora/") + deviceId + "/state", payload);
         }
+      } else if (msgType == "ack") {
+        mqtt.handleAck(deviceId, payload);
       }
       mqtt.publishGatewayStats(lastRSSI, lastSNR);
     }

--- a/test/test_gateway.cpp
+++ b/test/test_gateway.cpp
@@ -16,6 +16,12 @@ void test_device_registration() {
   TEST_ASSERT_EQUAL_STRING("temperature", reg.getType("temp1").c_str());
 }
 
+void test_device_registration_ack() {
+  DeviceRegistry reg;
+  reg.registerDevice("dev1", "relay", true);
+  TEST_ASSERT_TRUE(reg.requiresAck("dev1"));
+}
+
 void test_temperature_payload() {
   float t = 23.5f;
   String encoded = TemperatureSensorDevice::encode(t);
@@ -32,6 +38,7 @@ void test_relay_payload() {
 void setup() {
   UNITY_BEGIN();
   RUN_TEST(test_device_registration);
+  RUN_TEST(test_device_registration_ack);
   RUN_TEST(test_temperature_payload);
   RUN_TEST(test_relay_payload);
   UNITY_END();


### PR DESCRIPTION
## Summary
- allow devices to register with `ack` requirement and track in registry
- retry unacknowledged `cmd` actions and clear them on acknowledgement
- handle acknowledgements and resend logic through MQTT handler

## Testing
- `pio test -e native` *(fails: fatal error: Arduino.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68915aa905ec832b858dd95660cb6fae