### PR TITLE
Add device presence tracking

### DIFF
--- a/src/DeviceRegistry.cpp
+++ b/src/DeviceRegistry.cpp
@@ -1,7 +1,9 @@
 #include "DeviceRegistry.h"
 
-void DeviceRegistry::registerDevice(const String &id, const String &type, bool requiresAck) {
-  devices[id] = {id, type, requiresAck};
+void DeviceRegistry::registerDevice(const String &id, const String &type,
+                                    bool requiresAck, bool trackPresence) {
+  RegisteredDevice dev{id, type, requiresAck, trackPresence, true, millis()};
+  devices[id] = dev;
 }
 
 bool DeviceRegistry::isRegistered(const String &id) const {
@@ -22,5 +24,56 @@ bool DeviceRegistry::requiresAck(const String &id) const {
     return it->second.requiresAck;
   }
   return false;
+}
+
+bool DeviceRegistry::shouldTrackPresence(const String &id) const {
+  auto it = devices.find(id);
+  if (it != devices.end()) {
+    return it->second.trackPresence;
+  }
+  return false;
+}
+
+bool DeviceRegistry::isConnected(const String &id) const {
+  auto it = devices.find(id);
+  if (it != devices.end()) {
+    return it->second.connected;
+  }
+  return false;
+}
+
+unsigned long DeviceRegistry::getLastSeen(const String &id) const {
+  auto it = devices.find(id);
+  if (it != devices.end()) {
+    return it->second.lastSeen;
+  }
+  return 0;
+}
+
+bool DeviceRegistry::updateLastSeen(const String &id) {
+  auto it = devices.find(id);
+  if (it != devices.end()) {
+    it->second.lastSeen = millis();
+    if (it->second.trackPresence && !it->second.connected) {
+      it->second.connected = true;
+      return true;
+    }
+  }
+  return false;
+}
+
+void DeviceRegistry::setConnected(const String &id, bool connected) {
+  auto it = devices.find(id);
+  if (it != devices.end()) {
+    it->second.connected = connected;
+  }
+}
+
+std::vector<String> DeviceRegistry::getDeviceIds() const {
+  std::vector<String> ids;
+  for (const auto &pair : devices) {
+    ids.push_back(pair.first);
+  }
+  return ids;
 }
 

--- a/src/DeviceRegistry.h
+++ b/src/DeviceRegistry.h
@@ -2,19 +2,30 @@
 
 #include <Arduino.h>
 #include <map>
+#include <vector>
 
 struct RegisteredDevice {
   String id;
   String type;
   bool requiresAck;
+  bool trackPresence;
+  bool connected;
+  unsigned long lastSeen;
 };
 
 class DeviceRegistry {
  public:
-  void registerDevice(const String &id, const String &type, bool requiresAck = false);
+  void registerDevice(const String &id, const String &type, bool requiresAck = false,
+                      bool trackPresence = false);
   bool isRegistered(const String &id) const;
   String getType(const String &id) const;
   bool requiresAck(const String &id) const;
+  bool shouldTrackPresence(const String &id) const;
+  bool isConnected(const String &id) const;
+  unsigned long getLastSeen(const String &id) const;
+  bool updateLastSeen(const String &id);
+  void setConnected(const String &id, bool connected);
+  std::vector<String> getDeviceIds() const;
   size_t count() const { return devices.size(); }
 
  private:

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -10,6 +10,7 @@ MqttHandler mqtt(registry, lora);
 
 int lastRSSI = 0;
 float lastSNR = 0.0;
+static const unsigned long PRESENCE_TIMEOUT = 60000;
 
 void setup() {
   Serial.begin(115200);
@@ -40,23 +41,54 @@ void loop() {
 
       if (msgType == "register") {
         bool requireAck = false;
+        bool trackPresence = false;
         String type = payload;
         int comma = payload.indexOf(',');
         if (comma > 0) {
           type = payload.substring(0, comma);
-          String flag = payload.substring(comma + 1);
-          requireAck = (flag == "ack");
+          String flags = payload.substring(comma + 1);
+          int start = 0;
+          while (start >= 0) {
+            int next = flags.indexOf(',', start);
+            String flag = next == -1 ? flags.substring(start) : flags.substring(start, next);
+            if (flag == "ack") {
+              requireAck = true;
+            } else if (flag == "presence") {
+              trackPresence = true;
+            }
+            if (next == -1) break;
+            start = next + 1;
+          }
         }
-        registry.registerDevice(deviceId, type, requireAck);
+        registry.registerDevice(deviceId, type, requireAck, trackPresence);
         mqtt.publishState(String("lora/") + deviceId + "/state", "registered");
+        if (trackPresence) {
+          mqtt.publishState(String("lora/") + deviceId + "/state", "connected");
+        }
       } else if (msgType == "data") {
         if (registry.isRegistered(deviceId)) {
+          if (registry.updateLastSeen(deviceId)) {
+            mqtt.publishState(String("lora/") + deviceId + "/state", "connected");
+          }
           mqtt.publishState(String("lora/") + deviceId + "/state", payload);
         }
       } else if (msgType == "ack") {
+        if (registry.updateLastSeen(deviceId)) {
+          mqtt.publishState(String("lora/") + deviceId + "/state", "connected");
+        }
         mqtt.handleAck(deviceId, payload);
       }
       mqtt.publishGatewayStats(lastRSSI, lastSNR);
+    }
+  }
+
+  unsigned long now = millis();
+  for (const String &id : registry.getDeviceIds()) {
+    if (registry.shouldTrackPresence(id) && registry.isConnected(id)) {
+      if (now - registry.getLastSeen(id) > PRESENCE_TIMEOUT) {
+        registry.setConnected(id, false);
+        mqtt.publishState(String("lora/") + id + "/state", "disconnected");
+      }
     }
   }
 }

--- a/test/test_gateway.cpp
+++ b/test/test_gateway.cpp
@@ -35,12 +35,25 @@ void test_relay_payload() {
   TEST_ASSERT_EQUAL_STRING("relay1:cmd:ON", packet.c_str());
 }
 
+void test_presence_tracking() {
+  DeviceRegistry reg;
+  reg.registerDevice("dev1", "relay", false, true);
+  TEST_ASSERT_TRUE(reg.shouldTrackPresence("dev1"));
+  TEST_ASSERT_TRUE(reg.isConnected("dev1"));
+  reg.setConnected("dev1", false);
+  TEST_ASSERT_FALSE(reg.isConnected("dev1"));
+  bool reconnected = reg.updateLastSeen("dev1");
+  TEST_ASSERT_TRUE(reconnected);
+  TEST_ASSERT_TRUE(reg.isConnected("dev1"));
+}
+
 void setup() {
   UNITY_BEGIN();
   RUN_TEST(test_device_registration);
   RUN_TEST(test_device_registration_ack);
   RUN_TEST(test_temperature_payload);
   RUN_TEST(test_relay_payload);
+  RUN_TEST(test_presence_tracking);
   UNITY_END();
 }
 


### PR DESCRIPTION
## Summary
- allow devices to request presence tracking via new `presence` flag during registration
- monitor and publish `connected`/`disconnected` states for tracked devices
- cover presence tracking with a new unit test

## Testing
- `pio test -e native` *(fails: Arduino.h: No such file or directory)*
- `pio test -e esp32c3` *(fails: undefined reference to DeviceRegistry functions)*
- `pio run -e esp32c3`


------
https://chatgpt.com/codex/tasks/task_e_689166550784832bb7655ca59919fbcf