### PR TITLE
feat: add gateway protocol helper for devices

### DIFF
--- a/examples/Relay/Relay.ino
+++ b/examples/Relay/Relay.ino
@@ -1,29 +1,26 @@
 #include <Arduino.h>
 #include "LoRaHandler.h"
+#include "GatewayProtocol.h"
 #include "DeviceTypes/RelayDevice.h"
 #include "config.h"
 
 LoRaHandler lora;
+GatewayProtocol gateway(lora, "relay1", {"relay"}, true);
 bool relayState = false;
 
 void setup() {
   Serial.begin(115200);
   lora.begin();
-  lora.sendPacket("relay1:register:relay");
+  gateway.onCommand([](const String &sensor, const String &value) {
+    if (sensor == "relay") {
+      relayState = RelayDevice::decode(value);
+      Serial.println(String("Relay state: ") + (relayState ? "ON" : "OFF"));
+    }
+  });
+  gateway.begin();
 }
 
 void loop() {
-  int rssi; float snr;
-  if (lora.available()) {
-    String pkt = lora.receivePacket(rssi, snr);
-    int first = pkt.indexOf(':');
-    int second = pkt.indexOf(':', first + 1);
-    String msgType = pkt.substring(first + 1, second);
-    String payload = pkt.substring(second + 1);
-    if (msgType == "cmd") {
-      relayState = RelayDevice::decode(payload);
-      Serial.println(String("Relay state: ") + (relayState ? "ON" : "OFF"));
-    }
-  }
+  gateway.loop();
 }
 

--- a/examples/TemperatureSensor/TemperatureSensor.ino
+++ b/examples/TemperatureSensor/TemperatureSensor.ino
@@ -1,21 +1,22 @@
 #include <Arduino.h>
 #include "LoRaHandler.h"
+#include "GatewayProtocol.h"
 #include "DeviceTypes/TemperatureSensorDevice.h"
 #include "config.h"
 
 LoRaHandler lora;
+GatewayProtocol gateway(lora, "temp1", {"temperature"});
 
 void setup() {
   Serial.begin(115200);
   lora.begin();
-  // send registration packet: DEVICE_ID:MSG_TYPE:PAYLOAD
-  lora.sendPacket("temp1:register:temperature");
+  gateway.begin();
 }
 
 void loop() {
   float temperatureC = 24.3;
-  String payload = TemperatureSensorDevice::encode(temperatureC);
-  lora.sendPacket(String("temp1:data:") + payload);
+  gateway.sendData("temperature", TemperatureSensorDevice::encode(temperatureC));
+  gateway.loop();
   delay(10000);
 }
 

--- a/src/GatewayProtocol.cpp
+++ b/src/GatewayProtocol.cpp
@@ -1,0 +1,80 @@
+#include "GatewayProtocol.h"
+
+GatewayProtocol::GatewayProtocol(LoRaHandler &lora, const String &deviceId,
+                                 const std::vector<String> &sensors,
+                                 bool requireAck, bool trackPresence)
+    : lora(lora),
+      deviceId(deviceId),
+      sensors(sensors),
+      requireAck(requireAck),
+      trackPresence(trackPresence),
+      commandHandler(nullptr) {}
+
+void GatewayProtocol::begin() {
+  String payload;
+  for (size_t i = 0; i < sensors.size(); ++i) {
+    if (i > 0) {
+      payload += "|";
+    }
+    payload += sensors[i];
+  }
+  if (requireAck || trackPresence) {
+    payload += ",";
+    bool first = true;
+    if (requireAck) {
+      payload += "ack";
+      first = false;
+    }
+    if (trackPresence) {
+      if (!first) {
+        payload += ",";
+      }
+      payload += "presence";
+    }
+  }
+  lora.sendPacket(deviceId + String(":register:") + payload);
+}
+
+void GatewayProtocol::onCommand(CommandHandler handler) {
+  commandHandler = handler;
+}
+
+void GatewayProtocol::loop() {
+  int rssi;
+  float snr;
+  if (!lora.available()) {
+    return;
+  }
+  String pkt = lora.receivePacket(rssi, snr);
+  int first = pkt.indexOf(':');
+  int second = pkt.indexOf(':', first + 1);
+  if (first <= 0 || second <= first) {
+    return;
+  }
+  String id = pkt.substring(0, first);
+  String type = pkt.substring(first + 1, second);
+  String payload = pkt.substring(second + 1);
+  if (id != deviceId || type != "cmd") {
+    return;
+  }
+  int eq = payload.indexOf('=');
+  String actionType = "cmd";
+  String value = payload;
+  String sensor;
+  if (eq > 0) {
+    sensor = payload.substring(0, eq);
+    value = payload.substring(eq + 1);
+    actionType = sensor;
+  }
+  if (commandHandler) {
+    commandHandler(sensor, value);
+  }
+  if (requireAck) {
+    lora.sendPacket(deviceId + String(":ack:") + actionType);
+  }
+}
+
+void GatewayProtocol::sendData(const String &sensor, const String &value) {
+  lora.sendPacket(deviceId + String(":data:") + sensor + "=" + value);
+}
+

--- a/src/GatewayProtocol.h
+++ b/src/GatewayProtocol.h
@@ -1,0 +1,29 @@
+#pragma once
+
+#include <Arduino.h>
+#include <functional>
+#include <vector>
+#include "LoRaHandler.h"
+
+class GatewayProtocol {
+ public:
+  using CommandHandler = std::function<void(const String &sensor, const String &value)>;
+
+  GatewayProtocol(LoRaHandler &lora, const String &deviceId,
+                  const std::vector<String> &sensors,
+                  bool requireAck = false, bool trackPresence = false);
+
+  void begin();
+  void loop();
+  void sendData(const String &sensor, const String &value);
+  void onCommand(CommandHandler handler);
+
+ private:
+  LoRaHandler &lora;
+  String deviceId;
+  std::vector<String> sensors;
+  bool requireAck;
+  bool trackPresence;
+  CommandHandler commandHandler;
+};
+


### PR DESCRIPTION
## Summary
- add `GatewayProtocol` class to wrap LoRa gateway protocol for devices
- simplify Relay and TemperatureSensor examples using the new helper

## Testing
- `pio test` *(fails: undefined reference to `DeviceRegistry::registerDevice`)*

------
https://chatgpt.com/codex/tasks/task_e_689172ccbafc832ba10644cefaad9751