### PR TITLE
Adjust LoRa radio configuration

### DIFF
--- a/include/config.h
+++ b/include/config.h
@@ -26,6 +26,7 @@ extern const float LORA_FREQ;
 extern const float LORA_BW;
 extern const uint8_t LORA_SF;
 extern const uint8_t LORA_CR;
+extern const uint8_t LORA_SYNC_WORD;
 
 // Gateway stats publish interval (ms)
 extern const uint32_t GATEWAY_STATS_INTERVAL;

--- a/src/LoRaHandler.cpp
+++ b/src/LoRaHandler.cpp
@@ -10,6 +10,7 @@ int LoRaHandler::begin() {
   int state = radio.begin(LORA_FREQ, LORA_BW, LORA_SF, LORA_CR);
   if (state == RADIOLIB_ERR_NONE) {
     radio.setDio1Action(nullptr);
+    radio.setSyncWord(LORA_SYNC_WORD);
   }
   return state;
 }

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -9,10 +9,11 @@ const uint16_t MQTT_PORT = 1883;
 const char *MQTT_USER = "mqtt_user";
 const char *MQTT_PASSWORD = "mqtt_pass";
 
-const float LORA_FREQ = 915.0;
+const float LORA_FREQ = 915.5;
 const float LORA_BW = 125.0;
-const uint8_t LORA_SF = 7;
+const uint8_t LORA_SF = 9;
 const uint8_t LORA_CR = 5;
+const uint8_t LORA_SYNC_WORD = 0x34;
 
 const uint32_t GATEWAY_STATS_INTERVAL = 60000; // 60s
 


### PR DESCRIPTION
## Summary
- tune LoRa frequency to 915.5 MHz and shift to SF9
- define sync word 0x34 and apply during radio init

## Testing
- `pio test -e native` *(fails: undefined references to DeviceRegistry::* during link)*

------
https://chatgpt.com/codex/tasks/task_e_689b0d9a4c60832b860ddcd54754262e